### PR TITLE
[winrt support] Changes to make Boost System work on the Windows Runtime.

### DIFF
--- a/test/system_error_test.cpp
+++ b/test/system_error_test.cpp
@@ -1,7 +1,7 @@
 //  system_error_test.cpp  ---------------------------------------------------//
 
 //  Copyright Beman Dawes 2006
-
+//  Copyright (c) Microsoft Corporation 2014
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
@@ -40,7 +40,7 @@ namespace
     BOOST_TEST( ex.code().category() == system_category() );
 # ifdef BOOST_WINDOWS_API
     LANGID language_id;
-#   if !defined(__MINGW32__) && !defined(__CYGWIN__)
+#   if !defined(__MINGW32__) && !defined(__CYGWIN__) && !BOOST_PLAT_WINDOWS_RUNTIME
       language_id = ::GetUserDefaultUILanguage();
 #   else
       language_id = 0x0409; // Assume US English


### PR DESCRIPTION
Basically just use FormatMessageW without FORMAT_MESSAGE_FROM_SYSTEM. Determining whether the Windows Runtime is currently being targeted is done with a Boost Predef.
