### PR TITLE
Use non-NULL sentinel for boost::throws()

### DIFF
--- a/include/boost/system/error_code.hpp
+++ b/include/boost/system/error_code.hpp
@@ -419,14 +419,18 @@ namespace boost
 
   }  // namespace system
 
-  namespace detail { inline system::error_code * throws() { return 0; } }
-    //  Misuse of the error_code object is turned into a noisy failure by
-    //  poisoning the reference. This particular implementation doesn't
-    //  produce warnings or errors from popular compilers, is very efficient
-    //  (as determined by inspecting generated code), and does not suffer
-    //  from order of initialization problems. In practice, it also seems
-    //  cause user function error handling implementation errors to be detected
-    //  very early in the development cycle.
+  namespace detail 
+  { 
+    inline system::error_code * throws() 
+      { return reinterpret_cast<system::error_code *>(0x123); } 
+      //  Misuse of the error_code object is turned into a noisy failure by
+      //  poisoning the reference. This particular implementation doesn't
+      //  produce warnings or errors from popular compilers, is very efficient
+      //  (as determined by inspecting generated code), and does not suffer
+      //  from order of initialization problems. In practice, it also seems
+      //  cause user function error handling implementation errors to be detected
+      //  very early in the development cycle.
+  }
 
   inline system::error_code & throws()
     { return *detail::throws(); }


### PR DESCRIPTION
The contract for `boost::throws()` requires a function that advertises compliance to check whether the provided error code object is equivalent to the object represented by `boost::throws()`. Because `boost::throws()` is inlined, and because it returns a reference type, clang optimized this away in `clock_clock_p_d` because it is a reference being tested against `NULL`. The C++ spec states that references must be initialized, so the compiler is at liberty to make this optimization. This worked with the deprecated logic because there was a linked symbol to test. Replacing this with a non-NULL sentinel value allows this to work.