### PR TITLE
Merge to master: Use C++11 explicit conversion operator if available

### DIFF
--- a/doc/reference.html
+++ b/doc/reference.html
@@ -458,7 +458,7 @@ error_code</code> synopsis</a></h3>
       cont error_category &amp;  category() const noexcept;
       error_condition        default_error_condition() const noexcept;
       string                 message() const;
-      operator unspecified-bool-type() const;
+      explicit               operator bool() const noexcept;
 
     private:
       int val_;                     // <i>exposition only</i>
@@ -523,20 +523,10 @@ error_code</code> observers</a></h3>
   <pre><code>string message() const;</code></pre>
 <blockquote>
 <p><i>Returns:</i>&nbsp; <code>category().message( value())</code>.</p>
-  <p><i>Throws:</i> Nothing.</p>
 </blockquote>
-<pre>operator unspecified-bool-type() const;</pre>
+<pre>explicit operator bool() const noexcept;</pre>
 <blockquote>
-<p><i>Returns:</i> if <code>value() != 0</code>, returns a value that will evaluate
-<code>true</code> in a boolean context; otherwise, returns a value that will 
-evaluate <code>false</code> in a boolean context. The value type returned shall 
-not be convertible to <code>int</code>.</p>
-<p><i>Throws:</i> nothing.</p>
-<p><i>[Note: </i>This conversion can be used in contexts where a <code>bool</code> 
-is expected ( e.g., an <code>if</code> condition ); however, implicit conversions 
-( e.g., to <code>int</code>) that can occur with <code>bool</code> are not 
-allowed, eliminating some sources of user error. One possible implementation 
-choice for this type is pointer-to-member. <i>--end note ]</i></p>
+<p><i>Returns:</i> <code>value() != 0</code>.</p>
 </blockquote>
 <h2><a name="Class-error_condition">Class <code>error_condition</code></a></h2>
 <p>The class <code>error_condition</code> describes an object used to hold 
@@ -566,10 +556,10 @@ implementation specific. <i>--end note ]</i></p>
       void clear() noexcept;
 
       // observers:
-      int value() const noexcept;
-      const error_category &amp; category() const noexcept;
-      string message() const;
-      operator unspecified-bool-type () const noexcept;
+      int                    value() const noexcept;
+      const error_category&amp;  category() const noexcept;
+      string                 message() const;
+      explicit               operator bool() const noexcept;
 
     private:
       int val_;                      // <i>exposition only</i>
@@ -632,18 +622,9 @@ observers</a></h3>
 <blockquote>
   <p><i>Returns:</i> <code>category().message( value() )</code>.</p>
 </blockquote>
-<pre>operator unspecified-bool-type () const;</pre>
+<pre>explicit operator bool() const noexcept;</pre>
 <blockquote>
-  <p><i>Returns: </i>If <code>value() != 0</code>, returns a value that will 
-  evaluate <code>true</code> in a boolean context; otherwise, returns a value 
-  that will evaluate <code>false</code>. The return type shall not be 
-  convertible to <code>int</code>. </p>
-  <p><i>Throws:</i> Nothing.</p>
-  <p><i>&nbsp;[ Note:</i> This conversion can be used in contexts where a <code>bool</code> 
-  is expected ( e.g., an if condition ); however, implicit conversions ( e.g., to
-  <code>int</code>) that can occur with <code>bool</code> are not allowed, 
-  eliminating some sources of user error. One possible implementation choice for 
-  this type is pointer to member. <i>--end note</i> <i>]</i></p>
+  <p><i>Returns: </i> <code>value() != 0</code>. </p>
 </blockquote>
   <h2><a name="throws-object"><code>throws</code> object</a></h2>
   <pre>extern error_code throws;</pre>

--- a/include/boost/system/error_code.hpp
+++ b/include/boost/system/error_code.hpp
@@ -270,6 +270,12 @@ namespace boost
       const error_category &  category() const BOOST_SYSTEM_NOEXCEPT { return *m_cat; }
       std::string             message() const  { return m_cat->message(value()); }
 
+#   ifndef BOOST_NO_CXX11_EXPLICIT_CONVERSION_OPERATORS
+      explicit operator bool() const BOOST_SYSTEM_NOEXCEPT
+      {
+        return m_val != 0;
+      }
+#   else
       typedef void (*unspecified_bool_type)();
       static void unspecified_bool_true() {}
 
@@ -282,6 +288,7 @@ namespace boost
       {
         return m_val == 0;
       }
+#   endif
 
       // relationals:
       //  the more symmetrical non-member syntax allows enum
@@ -357,6 +364,12 @@ namespace boost
       error_condition         default_error_condition() const BOOST_SYSTEM_NOEXCEPT  { return m_cat->default_error_condition(value()); }
       std::string             message() const  { return m_cat->message(value()); }
 
+#   ifndef BOOST_NO_CXX11_EXPLICIT_CONVERSION_OPERATORS
+      explicit operator bool() const BOOST_SYSTEM_NOEXCEPT
+      {
+        return m_val != 0;
+      }
+#   else
       typedef void (*unspecified_bool_type)();
       static void unspecified_bool_true() {}
 
@@ -369,6 +382,7 @@ namespace boost
       {
         return m_val == 0;
       }
+#   endif
 
       // relationals:
       inline friend bool operator==( const error_code & lhs,

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -26,10 +26,10 @@ project
            : # command line
            : # input files
            : # requirements
-                   <link>static
+             <test-info>always_show_run_output <link>static
          ]
          [ run error_code_test.cpp
-           :  :  : <link>shared : error_code_test_shared
+           :  :  : <test-info>always_show_run_output <link>shared : error_code_test_shared
          ]
          [ run error_code_user_test.cpp
            :  :  : <link>static


### PR DESCRIPTION
This change brings leftover parts of commit
08ea984237321c015a03705612eca910a96643f8 to master, in order to synchronize it
with develop.

For some reason, this part did not get merged to master by https://github.com/boostorg/system/pull/11. After this change, develop and master should have equivalent contents.