### PR TITLE
Remove unread assignment

### DIFF
--- a/include/boost/system/detail/error_code.ipp
+++ b/include/boost/system/detail/error_code.ipp
@@ -151,7 +151,6 @@ namespace
 #   endif
 
       if ( sz > sizeof(buf) ) std::free( bp );
-      sz = 0;
       return msg;
   #  endif   // else POSIX version of strerror_r
   # endif  // else use strerror_r


### PR DESCRIPTION
The variable sz is not read after it is assigned to `0`. This shows up as an warning in clangs static analyzer.