### PR TITLE
Add conversions to std:: counterparts when <system_error> is available

### DIFF
--- a/include/boost/system/error_code.hpp
+++ b/include/boost/system/error_code.hpp
@@ -28,6 +28,10 @@
 #  error BOOST_POSIX_API or BOOST_WINDOWS_API must be defined
 #endif
 
+#ifndef BOOST_NO_CXX11_HDR_SYSTEM_ERROR
+#include <system_error>
+#endif
+
 #include <boost/config/abi_prefix.hpp> // must be the last #include
 
 #ifndef BOOST_SYSTEM_NOEXCEPT
@@ -181,10 +185,79 @@ namespace boost
 
     //  ----------------------------------------------------------------------//
 
+    class error_category;
+
+    //  predefined error categories  -----------------------------------------//
+
+#ifdef BOOST_ERROR_CODE_HEADER_ONLY
+    inline const error_category &  system_category() BOOST_SYSTEM_NOEXCEPT;
+    inline const error_category &  generic_category() BOOST_SYSTEM_NOEXCEPT;
+#else
+    BOOST_SYSTEM_DECL const error_category &  system_category() BOOST_SYSTEM_NOEXCEPT;
+    BOOST_SYSTEM_DECL const error_category &  generic_category() BOOST_SYSTEM_NOEXCEPT;
+#endif
+    //  deprecated synonyms --------------------------------------------------//
+
+#ifndef BOOST_SYSTEM_NO_DEPRECATED
+    inline const error_category &  get_system_category() { return system_category(); }
+    inline const error_category &  get_generic_category() { return generic_category(); }
+    inline const error_category &  get_posix_category() { return generic_category(); }
+    static const error_category &  posix_category BOOST_ATTRIBUTE_UNUSED = generic_category();
+    static const error_category &  errno_ecat     BOOST_ATTRIBUTE_UNUSED = generic_category();
+    static const error_category &  native_ecat    BOOST_ATTRIBUTE_UNUSED = system_category();
+#endif
+
     //  class error_category  ------------------------------------------------//
 
     class error_category : public noncopyable
     {
+#ifndef BOOST_NO_CXX11_HDR_SYSTEM_ERROR
+
+    private:
+
+      class std_category: public std::error_category
+      {
+      private:
+
+        boost::system::error_category const * pc_;
+
+      public:
+
+        explicit std_category( boost::system::error_category const * pc ): pc_( pc )
+        {
+        }
+
+        virtual const char * name() const BOOST_NOEXCEPT
+        {
+          return pc_->name();
+        }
+
+        virtual std::string message( int ev ) const
+        {
+          return pc_->message( ev );
+        }
+
+        virtual std::error_condition default_error_condition( int ev ) const BOOST_NOEXCEPT;
+      };
+
+      std_category std_cat_;
+
+    public:
+
+      error_category() BOOST_SYSTEM_NOEXCEPT: std_cat_( this ) {}
+
+      operator std::error_category const & () const BOOST_SYSTEM_NOEXCEPT
+      {
+        if( this == &generic_category() )
+        {
+          return std::generic_category();
+        }
+
+        return std_cat_;
+      }
+
+#endif
+
     public:
       virtual ~error_category(){}
 
@@ -203,26 +276,6 @@ namespace boost
         return std::less<const error_category*>()( this, &rhs );
       }
     };
-
-    //  predefined error categories  -----------------------------------------//
-
-# ifdef BOOST_ERROR_CODE_HEADER_ONLY
-    inline const error_category &  system_category() BOOST_SYSTEM_NOEXCEPT;
-    inline const error_category &  generic_category() BOOST_SYSTEM_NOEXCEPT;
-#else
-    BOOST_SYSTEM_DECL const error_category &  system_category() BOOST_SYSTEM_NOEXCEPT;
-    BOOST_SYSTEM_DECL const error_category &  generic_category() BOOST_SYSTEM_NOEXCEPT;
-#endif
-    //  deprecated synonyms --------------------------------------------------//
-
-# ifndef BOOST_SYSTEM_NO_DEPRECATED
-    inline const error_category &  get_system_category() { return system_category(); }
-    inline const error_category &  get_generic_category() { return generic_category(); }
-    inline const error_category &  get_posix_category() { return generic_category(); }
-    static const error_category &  posix_category BOOST_ATTRIBUTE_UNUSED = generic_category();
-    static const error_category &  errno_ecat     BOOST_ATTRIBUTE_UNUSED = generic_category();
-    static const error_category &  native_ecat    BOOST_ATTRIBUTE_UNUSED = system_category();
-# endif
 
     //  class error_condition  -----------------------------------------------//
 
@@ -308,11 +361,29 @@ namespace boost
           || (lhs.m_cat == rhs.m_cat && lhs.m_val < rhs.m_val);
       }
 
+#ifndef BOOST_NO_CXX11_HDR_SYSTEM_ERROR
+
+      operator std::error_condition () const BOOST_SYSTEM_NOEXCEPT
+      {
+        return std::error_condition( value(), category() );
+      }
+
+#endif
+
     private:
       int                     m_val;
       const error_category *  m_cat;
 
     };
+
+#ifndef BOOST_NO_CXX11_HDR_SYSTEM_ERROR
+
+    inline std::error_condition error_category::std_category::default_error_condition( int ev ) const BOOST_NOEXCEPT
+    {
+      return pc_->default_error_condition( ev );
+    }
+
+#endif
 
     //  class error_code  ----------------------------------------------------//
 
@@ -401,6 +472,15 @@ namespace boost
         return lhs.m_cat < rhs.m_cat
           || (lhs.m_cat == rhs.m_cat && lhs.m_val < rhs.m_val);
       }
+
+#ifndef BOOST_NO_CXX11_HDR_SYSTEM_ERROR
+
+      operator std::error_code () const BOOST_SYSTEM_NOEXCEPT
+      {
+        return std::error_code( value(), category() );
+      }
+
+#endif
 
     private:
       int                     m_val;

--- a/include/boost/system/error_code.hpp
+++ b/include/boost/system/error_code.hpp
@@ -238,6 +238,7 @@ namespace boost
         }
 
         virtual std::error_condition default_error_condition( int ev ) const BOOST_NOEXCEPT;
+        virtual bool equivalent( int code, const std::error_condition & condition ) const BOOST_NOEXCEPT;
       };
 
       std_category std_cat_;
@@ -248,7 +249,7 @@ namespace boost
 
       operator std::error_category const & () const BOOST_SYSTEM_NOEXCEPT
       {
-        if( this == &generic_category() )
+        if( *this == generic_category() )
         {
           return std::generic_category();
         }
@@ -375,15 +376,6 @@ namespace boost
       const error_category *  m_cat;
 
     };
-
-#ifndef BOOST_NO_CXX11_HDR_SYSTEM_ERROR
-
-    inline std::error_condition error_category::std_category::default_error_condition( int ev ) const BOOST_NOEXCEPT
-    {
-      return pc_->default_error_condition( ev );
-    }
-
-#endif
 
     //  class error_code  ----------------------------------------------------//
 
@@ -600,6 +592,27 @@ namespace boost
     {
       return *this == code.category() && code.value() == condition;
     }
+
+#ifndef BOOST_NO_CXX11_HDR_SYSTEM_ERROR
+
+    inline std::error_condition error_category::std_category::default_error_condition( int ev ) const BOOST_NOEXCEPT
+    {
+      return pc_->default_error_condition( ev );
+    }
+
+    inline bool error_category::std_category::equivalent( int code, const std::error_condition & condition ) const BOOST_NOEXCEPT
+    {
+      if( condition.category() == std::generic_category() )
+      {
+        return pc_->equivalent( code, boost::system::error_condition( condition.value(), boost::system::generic_category() ) );
+      }
+      else
+      {
+        return default_error_condition( code ) == condition;
+      }
+    }
+
+#endif
 
   } // namespace system
 } // namespace boost

--- a/include/boost/system/error_code.hpp
+++ b/include/boost/system/error_code.hpp
@@ -250,22 +250,9 @@ namespace boost
 
       operator std::error_category const & () const BOOST_SYSTEM_NOEXCEPT
       {
-        if( *this == generic_category() )
-        {
-          std::error_category const & st = std::generic_category();
-
-          int ev = ENOENT;
-
-          // if the standard generic category works, use it; else not
-          if( st.equivalent( ev, st.default_error_condition( ev ) ) )
-          {
-            // g++ 4.x with libstdc++ 5 installed fails, because the two
-            // generic categories, v1 and v2, get mixed up
-
-            return st;
-          }
-        }
-
+        // do not map generic to std::generic on purpose; occasionally,
+        // there are two std::generic categories in a program, which leads
+        // to error codes/conditions mysteriously not being equal to themselves
         return std_cat_;
       }
 
@@ -618,7 +605,7 @@ namespace boost
       {
         return true;
       }
-      else if( condition.category() == std::generic_category() )
+      else if( condition.category() == std::generic_category() || condition.category() == boost::system::generic_category() )
       {
         return pc_->equivalent( code, boost::system::error_condition( condition.value(), boost::system::generic_category() ) );
       }

--- a/include/boost/system/error_code.hpp
+++ b/include/boost/system/error_code.hpp
@@ -607,8 +607,20 @@ namespace boost
       }
       else if( condition.category() == std::generic_category() || condition.category() == boost::system::generic_category() )
       {
-        return pc_->equivalent( code, boost::system::error_condition( condition.value(), boost::system::generic_category() ) );
+        boost::system::error_code bc( code, *pc_ );
+        boost::system::error_condition bn( condition.value(), boost::system::generic_category() );
+
+        return bc == bn;
       }
+#ifndef BOOST_NO_RTTI
+      else if( std_category const* pc2 = dynamic_cast< std_category const* >( &condition.category() ) )
+      {
+        boost::system::error_code bc( code, *pc_ );
+        boost::system::error_condition bn( condition.value(), *pc2->pc_ );
+
+        return bc == bn;
+      }
+#endif
       else
       {
         return false;
@@ -623,8 +635,7 @@ namespace boost
       }
       else if( *pc_ == boost::system::generic_category() )
       {
-        std::error_category const & st = std::generic_category();
-        return st.equivalent( code, condition );
+        return code == std::error_condition( condition, std::generic_category() );
       }
       else
       {
@@ -644,5 +655,3 @@ namespace boost
 # endif
 
 #endif // BOOST_SYSTEM_ERROR_CODE_HPP
-
-

--- a/include/boost/system/error_code.hpp
+++ b/include/boost/system/error_code.hpp
@@ -239,6 +239,7 @@ namespace boost
 
         virtual std::error_condition default_error_condition( int ev ) const BOOST_NOEXCEPT;
         virtual bool equivalent( int code, const std::error_condition & condition ) const BOOST_NOEXCEPT;
+        virtual bool equivalent( const std::error_code & code, int condition ) const BOOST_NOEXCEPT;
       };
 
       std_category std_cat_;
@@ -613,13 +614,34 @@ namespace boost
 
     inline bool error_category::std_category::equivalent( int code, const std::error_condition & condition ) const BOOST_NOEXCEPT
     {
-      if( condition.category() == std::generic_category() )
+      if( default_error_condition( code ) == condition )
+      {
+        return true;
+      }
+      else if( condition.category() == std::generic_category() )
       {
         return pc_->equivalent( code, boost::system::error_condition( condition.value(), boost::system::generic_category() ) );
       }
       else
       {
-        return default_error_condition( code ) == condition;
+        return false;
+      }
+    }
+
+    inline bool error_category::std_category::equivalent( const std::error_code & code, int condition ) const BOOST_NOEXCEPT
+    {
+      if( *this == code.category() && code.value() == condition )
+      {
+        return true;
+      }
+      else if( *pc_ == boost::system::generic_category() )
+      {
+        std::error_category const & st = std::generic_category();
+        return st.equivalent( code, condition );
+      }
+      else
+      {
+        return false;
       }
     }
 

--- a/include/boost/system/error_code.hpp
+++ b/include/boost/system/error_code.hpp
@@ -251,7 +251,18 @@ namespace boost
       {
         if( *this == generic_category() )
         {
-          return std::generic_category();
+          std::error_category const & st = std::generic_category();
+
+          int ev = ENOENT;
+
+          // if the standard generic category works, use it; else not
+          if( st.equivalent( ev, st.default_error_condition( ev ) ) )
+          {
+            // g++ 4.x with libstdc++ 5 installed fails, because the two
+            // generic categories, v1 and v2, get mixed up
+
+            return st;
+          }
         }
 
         return std_cat_;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -55,4 +55,10 @@ project
          [ run config_test.cpp
            :  :  : <test-info>always_show_run_output 
          ]
+         [ run std_interop_test.cpp
+           :  :  : <link>static
+         ]
+         [ run std_interop_test.cpp
+            :  :  : <link>shared : std_interop_test_shared
+         ]
          ;

--- a/test/std_interop_test.cpp
+++ b/test/std_interop_test.cpp
@@ -34,17 +34,40 @@ static void test_generic_category()
     int ev = ENOENT;
     // BOOST_TEST_EQ( bt.message( ev ), st.message( ev ) );
 
-    boost::system::error_condition bn = bt.default_error_condition( ev );
-    BOOST_TEST( bt.equivalent( ev, bn ) );
+    {
+        boost::system::error_code bc( ev, bt );
 
-    BOOST_TEST_EQ( bn.value(), ev );
-    BOOST_TEST_EQ( &bn.category(), &bt );
+        BOOST_TEST_EQ( bc.value(), ev );
+        BOOST_TEST_EQ( &bc.category(), &bt );
 
-    std::error_condition sn( bn );
-    BOOST_TEST( st.equivalent( ev, sn ) );
+        std::error_code sc( bc );
 
-    BOOST_TEST_EQ( sn.value(), ev );
-    BOOST_TEST_EQ( &sn.category(), &st );
+        BOOST_TEST_EQ( sc.value(), ev );
+        BOOST_TEST_EQ( &sc.category(), &st );
+    }
+
+    {
+        boost::system::error_condition bn = bt.default_error_condition( ev );
+
+        BOOST_TEST_EQ( bn.value(), ev );
+        BOOST_TEST_EQ( &bn.category(), &bt );
+
+        BOOST_TEST( bt.equivalent( ev, bn ) );
+
+        std::error_condition sn( bn );
+
+        BOOST_TEST_EQ( sn.value(), ev );
+        BOOST_TEST_EQ( &sn.category(), &st );
+
+        BOOST_TEST( st.equivalent( ev, sn ) );
+
+        std::error_condition sn2 = st.default_error_condition( ev );
+
+        BOOST_TEST_EQ( sn2.value(), ev );
+        BOOST_TEST_EQ( &sn2.category(), &st );
+
+        BOOST_TEST( st.equivalent( ev, sn2 ) );
+    }
 }
 
 static void test_system_category()
@@ -58,22 +81,50 @@ static void test_system_category()
         int ev = 5;
         BOOST_TEST_EQ( bt.message( ev ), st.message( ev ) );
 
-        boost::system::error_condition bn = bt.default_error_condition( ev );
-        BOOST_TEST( bt.equivalent( ev, bn ) );
+        {
+            boost::system::error_code bc( ev, bt );
 
-        std::error_condition sn( bn );
-        BOOST_TEST( st.equivalent( ev, sn ) );
+            BOOST_TEST_EQ( bc.value(), ev );
+            BOOST_TEST_EQ( &bc.category(), &bt );
+
+            std::error_code sc( bc );
+
+            BOOST_TEST_EQ( sc.value(), ev );
+            BOOST_TEST_EQ( &sc.category(), &st );
+        }
+
+        {
+            boost::system::error_condition bn = bt.default_error_condition( ev );
+            BOOST_TEST( bt.equivalent( ev, bn ) );
+
+            std::error_condition sn( bn );
+            BOOST_TEST( st.equivalent( ev, sn ) );
+        }
     }
 
     {
         int ev = 4;
         BOOST_TEST_EQ( bt.message( ev ), st.message( ev ) );
 
-        boost::system::error_condition bn = bt.default_error_condition( ev );
-        BOOST_TEST( bt.equivalent( ev, bn ) );
+        {
+            boost::system::error_code bc( ev, bt );
 
-        std::error_condition sn( bn );
-        BOOST_TEST( st.equivalent( ev, sn ) );
+            BOOST_TEST_EQ( bc.value(), ev );
+            BOOST_TEST_EQ( &bc.category(), &bt );
+
+            std::error_code sc( bc );
+
+            BOOST_TEST_EQ( sc.value(), ev );
+            BOOST_TEST_EQ( &sc.category(), &st );
+        }
+
+        {
+            boost::system::error_condition bn = bt.default_error_condition( ev );
+            BOOST_TEST( bt.equivalent( ev, bn ) );
+
+            std::error_condition sn( bn );
+            BOOST_TEST( st.equivalent( ev, sn ) );
+        }
     }
 }
 
@@ -145,16 +196,42 @@ static void test_user_category()
         int ev = 5;
         BOOST_TEST_EQ( bt.message( ev ), st.message( ev ) );
 
-        boost::system::error_condition bn = bt.default_error_condition( ev );
-        BOOST_TEST( bt.equivalent( ev, bn ) );
+        {
+            boost::system::error_code bc( ev, bt );
 
-        std::error_condition sn( bn );
-        BOOST_TEST( st.equivalent( ev, sn ) );
+            BOOST_TEST_EQ( bc.value(), ev );
+            BOOST_TEST_EQ( &bc.category(), &bt );
+
+            std::error_code sc( bc );
+
+            BOOST_TEST_EQ( sc.value(), ev );
+            BOOST_TEST_EQ( &sc.category(), &st );
+        }
+
+        {
+            boost::system::error_condition bn = bt.default_error_condition( ev );
+            BOOST_TEST( bt.equivalent( ev, bn ) );
+
+            std::error_condition sn( bn );
+            BOOST_TEST( st.equivalent( ev, sn ) );
+        }
     }
 
     {
         int ev = 4;
         BOOST_TEST_EQ( bt.message( ev ), st.message( ev ) );
+
+        {
+            boost::system::error_code bc( ev, bt );
+
+            BOOST_TEST_EQ( bc.value(), ev );
+            BOOST_TEST_EQ( &bc.category(), &bt );
+
+            std::error_code sc( bc );
+
+            BOOST_TEST_EQ( sc.value(), ev );
+            BOOST_TEST_EQ( &sc.category(), &st );
+        }
 
         {
             boost::system::error_condition bn = bt.default_error_condition( ev );

--- a/test/std_interop_test.cpp
+++ b/test/std_interop_test.cpp
@@ -1,0 +1,188 @@
+
+// Copyright 2017 Peter Dimov.
+//
+// Distributed under the Boost Software License, Version 1.0.
+//
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+
+// See library home page at http://www.boost.org/libs/system
+
+#include <boost/config.hpp>
+
+#if defined(BOOST_NO_CXX11_HDR_SYSTEM_ERROR)
+
+int main() {}
+
+#else
+
+#include <boost/system/error_code.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <system_error>
+#include <cerrno>
+#include <string>
+
+static void test_generic_category()
+{
+    boost::system::error_category const & bt = boost::system::generic_category();
+    std::error_category const & st = bt;
+
+    BOOST_TEST_EQ( &st, &std::generic_category() );
+
+    BOOST_TEST_CSTR_EQ( bt.name(), st.name() );
+
+    int ev = ENOENT;
+    // BOOST_TEST_EQ( bt.message( ev ), st.message( ev ) );
+
+    boost::system::error_condition bn = bt.default_error_condition( ev );
+    BOOST_TEST( bt.equivalent( ev, bn ) );
+
+    std::error_condition sn( bn );
+    BOOST_TEST( st.equivalent( ev, sn ) );
+}
+
+static void test_system_category()
+{
+    boost::system::error_category const & bt = boost::system::system_category();
+    std::error_category const & st = bt;
+
+    BOOST_TEST_CSTR_EQ( bt.name(), st.name() );
+
+    {
+        int ev = 5;
+        BOOST_TEST_EQ( bt.message( ev ), st.message( ev ) );
+
+        boost::system::error_condition bn = bt.default_error_condition( ev );
+        BOOST_TEST( bt.equivalent( ev, bn ) );
+
+        std::error_condition sn( bn );
+        BOOST_TEST( st.equivalent( ev, sn ) );
+    }
+
+    {
+        int ev = 4;
+        BOOST_TEST_EQ( bt.message( ev ), st.message( ev ) );
+
+        boost::system::error_condition bn = bt.default_error_condition( ev );
+        BOOST_TEST( bt.equivalent( ev, bn ) );
+
+        std::error_condition sn( bn );
+        BOOST_TEST( st.equivalent( ev, sn ) );
+    }
+}
+
+class user_category_impl: public boost::system::error_category
+{
+public:
+
+    virtual const char * name() const BOOST_NOEXCEPT
+    {
+        return "user";
+    }
+
+    virtual std::string message( int ev ) const
+    {
+        char buffer[ 256 ];
+        sprintf( buffer, "user message %d", ev );
+
+        return buffer;
+    }
+
+    virtual boost::system::error_condition default_error_condition( int ev ) const BOOST_NOEXCEPT
+    {
+        if( ev == 4 )
+        {
+            return boost::system::error_condition( EMFILE, boost::system::generic_category() );
+        }
+        else if( ev == 5 )
+        {
+            return boost::system::error_condition( EACCES, boost::system::generic_category() );
+        }
+        else
+        {
+            return boost::system::error_condition( ev, *this );
+        }
+    }
+
+    virtual bool equivalent( int code, const boost::system::error_condition & condition ) const BOOST_NOEXCEPT
+    {
+        if( code == 4 && condition == make_error_condition( boost::system::errc::too_many_files_open_in_system ) )
+        {
+            return true;
+        }
+
+        if( code == 4 && condition == make_error_condition( boost::system::errc::too_many_files_open ) )
+        {
+            return true;
+        }
+
+        return default_error_condition( code ) == condition;
+    }
+
+    // virtual bool equivalent( const error_code & code, int condition ) const BOOST_NOEXCEPT;
+};
+
+boost::system::error_category const & user_category()
+{
+    static user_category_impl cat_;
+    return cat_;
+}
+
+static void test_user_category()
+{
+    boost::system::error_category const & bt = user_category();
+    std::error_category const & st = bt;
+
+    BOOST_TEST_CSTR_EQ( bt.name(), st.name() );
+
+    {
+        int ev = 5;
+        BOOST_TEST_EQ( bt.message( ev ), st.message( ev ) );
+
+        boost::system::error_condition bn = bt.default_error_condition( ev );
+        BOOST_TEST( bt.equivalent( ev, bn ) );
+
+        std::error_condition sn( bn );
+        BOOST_TEST( st.equivalent( ev, sn ) );
+    }
+
+    {
+        int ev = 4;
+        BOOST_TEST_EQ( bt.message( ev ), st.message( ev ) );
+
+        {
+            boost::system::error_condition bn = bt.default_error_condition( ev );
+            BOOST_TEST( bt.equivalent( ev, bn ) );
+
+            std::error_condition sn( bn );
+            BOOST_TEST( st.equivalent( ev, sn ) );
+        }
+
+        {
+            boost::system::error_condition bn = make_error_condition( boost::system::errc::too_many_files_open_in_system );
+            BOOST_TEST( bt.equivalent( ev, bn ) );
+
+            std::error_condition sn( bn );
+            BOOST_TEST( st.equivalent( ev, sn ) );
+        }
+
+        {
+            boost::system::error_condition bn = make_error_condition( boost::system::errc::too_many_files_open );
+            BOOST_TEST( bt.equivalent( ev, bn ) );
+
+            std::error_condition sn( bn );
+            BOOST_TEST( st.equivalent( ev, sn ) );
+        }
+    }
+}
+
+int main()
+{
+    test_generic_category();
+    test_system_category();
+    test_user_category();
+
+    return boost::report_errors();
+}
+
+#endif

--- a/test/std_interop_test.cpp
+++ b/test/std_interop_test.cpp
@@ -24,28 +24,14 @@ int main() {}
 
 static void test_generic_category()
 {
-    int ev = ENOENT;
-
-    // check whether the standard generic category works
-
-    std::error_category const & st0 = std::generic_category();
-    bool has_roundtrip = st0.equivalent( ev, st0.default_error_condition( ev ) );
-
-    //
-
     boost::system::error_category const & bt = boost::system::generic_category();
     std::error_category const & st = bt;
 
     BOOST_TEST_CSTR_EQ( bt.name(), st.name() );
 
-    if( has_roundtrip )
-    {
-        BOOST_TEST_EQ( &st, &std::generic_category() );
-    }
-    else
-    {
-        BOOST_TEST_EQ( bt.message( ev ), st.message( ev ) );
-    }
+    int ev = ENOENT;
+
+    BOOST_TEST_EQ( bt.message( ev ), st.message( ev ) );
 
     {
         boost::system::error_code bc( ev, bt );

--- a/test/std_interop_test.cpp
+++ b/test/std_interop_test.cpp
@@ -37,8 +37,14 @@ static void test_generic_category()
     boost::system::error_condition bn = bt.default_error_condition( ev );
     BOOST_TEST( bt.equivalent( ev, bn ) );
 
+    BOOST_TEST_EQ( bn.value(), ev );
+    BOOST_TEST_EQ( &bn.category(), &bt );
+
     std::error_condition sn( bn );
     BOOST_TEST( st.equivalent( ev, sn ) );
+
+    BOOST_TEST_EQ( sn.value(), ev );
+    BOOST_TEST_EQ( &sn.category(), &st );
 }
 
 static void test_system_category()

--- a/test/std_interop_test.cpp
+++ b/test/std_interop_test.cpp
@@ -120,6 +120,8 @@ static void test_system_category()
     }
 }
 
+// test_user_category
+
 class user_category_impl: public boost::system::error_category
 {
 public:
@@ -251,11 +253,103 @@ static void test_user_category()
     }
 }
 
+// test_user2_category
+
+enum user2_errc
+{
+    my_enoent = 1,
+    my_einval,
+    my_other
+};
+
+class user2_category_impl: public boost::system::error_category
+{
+public:
+
+    virtual const char * name() const BOOST_NOEXCEPT
+    {
+        return "user2";
+    }
+
+    virtual std::string message( int ev ) const
+    {
+        char buffer[ 256 ];
+        sprintf( buffer, "user2 message %d", ev );
+
+        return buffer;
+    }
+
+    virtual boost::system::error_condition default_error_condition( int ev ) const BOOST_NOEXCEPT
+    {
+        return boost::system::error_condition( ev, *this );
+    }
+
+    virtual bool equivalent( int code, const boost::system::error_condition & condition ) const BOOST_NOEXCEPT
+    {
+        return default_error_condition( code ) == condition;
+    }
+
+    virtual bool equivalent( const boost::system::error_code & code, int condition ) const BOOST_NOEXCEPT
+    {
+        if( code.category() == *this )
+        {
+            return condition == code.value();
+        }
+        else if( condition == my_enoent )
+        {
+            return code == boost::system::errc::no_such_file_or_directory;
+        }
+        else if( condition == my_einval )
+        {
+            return code == boost::system::errc::invalid_argument;
+        }
+        else
+        {
+            return false;
+        }
+    }
+};
+
+boost::system::error_category const & user2_category()
+{
+    static user2_category_impl cat_;
+    return cat_;
+}
+
+static void test_user2_category()
+{
+    boost::system::error_category const & bt = user2_category();
+    std::error_category const & st = bt;
+
+    int ev = my_enoent;
+
+    boost::system::error_condition bn( ev, bt );
+
+    BOOST_TEST_EQ( bn.value(), ev );
+    BOOST_TEST_EQ( &bn.category(), &bt );
+
+    boost::system::error_code bc = make_error_code( boost::system::errc::no_such_file_or_directory );
+
+    BOOST_TEST( bc == bn );
+
+    std::error_condition sn( bn );
+
+    BOOST_TEST_EQ( sn.value(), ev );
+    BOOST_TEST_EQ( &sn.category(), &st );
+
+    std::error_code sc( bc );
+
+    BOOST_TEST( sc == sn );
+}
+
+//
+
 int main()
 {
     test_generic_category();
     test_system_category();
     test_user_category();
+    test_user2_category();
 
     return boost::report_errors();
 }

--- a/test/std_interop_test.cpp
+++ b/test/std_interop_test.cpp
@@ -24,15 +24,28 @@ int main() {}
 
 static void test_generic_category()
 {
+    int ev = ENOENT;
+
+    // check whether the standard generic category works
+
+    std::error_category const & st0 = std::generic_category();
+    bool has_roundtrip = st0.equivalent( ev, st0.default_error_condition( ev ) );
+
+    //
+
     boost::system::error_category const & bt = boost::system::generic_category();
     std::error_category const & st = bt;
 
-    BOOST_TEST_EQ( &st, &std::generic_category() );
-
     BOOST_TEST_CSTR_EQ( bt.name(), st.name() );
 
-    int ev = ENOENT;
-    // BOOST_TEST_EQ( bt.message( ev ), st.message( ev ) );
+    if( has_roundtrip )
+    {
+        BOOST_TEST_EQ( &st, &std::generic_category() );
+    }
+    else
+    {
+        BOOST_TEST_EQ( bt.message( ev ), st.message( ev ) );
+    }
 
     {
         boost::system::error_code bc( ev, bt );
@@ -60,13 +73,6 @@ static void test_generic_category()
         BOOST_TEST_EQ( &sn.category(), &st );
 
         BOOST_TEST( st.equivalent( ev, sn ) );
-
-        std::error_condition sn2 = st.default_error_condition( ev );
-
-        BOOST_TEST_EQ( sn2.value(), ev );
-        BOOST_TEST_EQ( &sn2.category(), &st );
-
-        BOOST_TEST( st.equivalent( ev, sn2 ) );
     }
 }
 


### PR DESCRIPTION
This adds conversions from `boost::system::error_{category, error, condition}` to `std::` same. Very useful for people who are already on C++11 but need to use libraries such as Boost.ASIO that still report status via `boost::system::error_code`.