### PR TITLE
std::basic_string::size() may return a size_type which is wider than …

### DIFF
--- a/include/boost/system/detail/error_code.ipp
+++ b/include/boost/system/detail/error_code.ipp
@@ -410,7 +410,7 @@ namespace
         }
     }
     
-    int num_chars = (buf.size() + 1) * 2;
+    int num_chars = static_cast<int>(buf.size() + 1) * 2;
 
     boost::winapi::LPSTR_ narrow_buffer =
 #if defined(__GNUC__)


### PR DESCRIPTION
…an int.

Signed-off-by: Daniela Engert <dani@ngrt.de>