### PR TITLE
[CMake] Add minimal CMake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright 2018 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: CMake support for Boost.System is currently experimental at best
+#       and the interface is likely to change in the future
+
+cmake_minimum_required(VERSION 3.5)
+project(BoostSystem)
+
+add_library(boost_system INTERFACE)
+
+add_library(Boost::system ALIAS boost_system)
+
+target_include_directories(boost_system INTERFACE include)
+
+target_link_libraries(boost_system
+    INTERFACE
+        Boost::config
+        Boost::winapi
+)
+


### PR DESCRIPTION
I'm not quite sure, what to do with the winapi dependency. It doesn't seem as if Boost.WinApi will gain a cmake file anytime soon (https://github.com/boostorg/winapi/pull/73), so this PR will currently only work under linux. 

I see multiple possible workarounds:
1. Don't add cmake support for boost.system at all until Boost::winapi is available (if ever) 
2. Only enable cmake on posix systems
3. Ignore the dependency on winapi on the cmake level and let users that actually include the respective headers deal with it
4. Add a dumy Boost::winapi target
5. Let the user that calls this CMakeList.txt file provide a `Boost::winapi` target
6. Add the winapi include directory to the target interface include directories
7.Check for the availability of Boost::winapi target and if it is not, create a differently named dummy 

- Workarounds 1 and 2 are imho the most undesireable solutions due to the ripple effect
- 3 is not very user friendly but might work in many situations, where the winapi header files are anyway in the system lookup path but on the other hand, this can lead to subtle errors if there is a version missmatch.
- Number 4 has the problem that it will likely collide with other dumy targets and we have to guess the location of the winapi headers (most likely ../winapi/include).
- 5 is again not too user friendly but on the other hand it is the most flexible solution, as the user probably knows best where to get the winapi headers from and if he needs them at all
- 6 Seems the simplest workaround to me with the only drawback that we still have to guess the include path
- 7 Is a bit more robust than 6, as it picks up the winapi target if it is provided (e.g. by the user or a modified version of the winapi library itself) but also more ugly 
