### PR TITLE
Wrong null character stripping for FormatMessage

### DIFF
--- a/test/system_category_test.cpp
+++ b/test/system_category_test.cpp
@@ -101,7 +101,9 @@ static void test_message( sys::error_category const & cat, int ev )
     BOOST_TEST_EQ( cat.message( ev ), sys_strerror( ev ) );
 
     char buffer[ 4096 ]; // yes, really
-    BOOST_TEST_CSTR_EQ( cat.message( ev, buffer, sizeof( buffer ) ), sys_strerror( ev ).c_str() );
+    std::string expected = sys_strerror( ev );
+    BOOST_TEST_CSTR_EQ( cat.message( ev, buffer, sizeof( buffer ) ), expected.c_str() );
+    BOOST_TEST_CSTR_EQ( cat.message( ev ).c_str(), expected.c_str() );
 }
 
 int main()
@@ -110,14 +112,7 @@ int main()
 
     // message
 
-    for( int i = -2; i < 1024; ++i )
-    {
-        test_message( cat, i );
-    }
-
-    test_message( cat, 5810 );
-
-    for( int i = 10000; i < 11032; ++i )
+    for( int i = -2; i <= 15999; ++i )
     {
         test_message( cat, i );
     }


### PR DESCRIPTION
FormatMessage
=============
> If the function succeeds, the return value is the number of TCHARs
> stored in the output buffer, excluding the terminating null character.

WideCharToMultiByte
===================
> cchWideChar
>
> If this parameter is -1, the function processes the entire input string,
> including the terminating null character. Therefore, the resulting
> character string has a terminating null character, and the length
> returned by the function includes this character.