### PR TITLE
Added boost::winapi::ERROR_CONNECTION_ABORTED_ to handled error codes…

### DIFF
--- a/include/boost/system/detail/system_category_win32.hpp
+++ b/include/boost/system/detail/system_category_win32.hpp
@@ -264,6 +264,7 @@ inline error_condition system_category_default_error_condition_win32( int ev ) B
     case ERROR_CANTOPEN_: return make_error_condition( io_error );
     case ERROR_CANTREAD_: return make_error_condition( io_error );
     case ERROR_CANTWRITE_: return make_error_condition( io_error );
+    case ERROR_CONNECTION_ABORTED_: return make_error_condition( connection_aborted );
     case ERROR_CURRENT_DIRECTORY_: return make_error_condition( permission_denied );
     case ERROR_DEV_NOT_EXIST_: return make_error_condition( no_such_device );
     case ERROR_DEVICE_IN_USE_: return make_error_condition( device_or_resource_busy );


### PR DESCRIPTION
… in Win32's system_category, making it equivalent to errc::connection_aborted