### PR TITLE
Fix c++17 warning redundant redeclaration of 'constexpr' static data

### DIFF
--- a/include/boost/system/error_code.hpp
+++ b/include/boost/system/error_code.hpp
@@ -335,8 +335,11 @@ template<class T> struct BOOST_SYMBOL_VISIBLE cat_holder
     static constexpr generic_error_category generic_category_instance{};
 };
 
+// Before C++17 it was mandatory to redeclare all static constexpr
+#if defined(BOOST_NO_CXX17_INLINE_VARIABLES)
 template<class T> constexpr system_error_category cat_holder<T>::system_category_instance;
 template<class T> constexpr generic_error_category cat_holder<T>::generic_category_instance;
+#endif
 
 } // namespace detail
 


### PR DESCRIPTION
member [-Werror=deprecated]