### PR TITLE
Use BOOST_OVERRIDE

### DIFF
--- a/include/boost/system/detail/std_interoperability.hpp
+++ b/include/boost/system/detail/std_interoperability.hpp
@@ -7,10 +7,11 @@
 //
 // See library home page at http://www.boost.org/libs/system
 
-#include <system_error>
+#include <boost/config.hpp>
 #include <map>
 #include <memory>
 #include <mutex>
+#include <system_error>
 
 //
 
@@ -47,23 +48,23 @@ public:
         }
     }
 
-    virtual const char * name() const BOOST_NOEXCEPT
+    const char * name() const BOOST_NOEXCEPT BOOST_OVERRIDE
     {
         return pc_->name();
     }
 
-    virtual std::string message( int ev ) const
+    std::string message( int ev ) const BOOST_OVERRIDE
     {
         return pc_->message( ev );
     }
 
-    virtual std::error_condition default_error_condition( int ev ) const BOOST_NOEXCEPT
+    std::error_condition default_error_condition( int ev ) const BOOST_NOEXCEPT BOOST_OVERRIDE
     {
         return pc_->default_error_condition( ev );
     }
 
-    virtual bool equivalent( int code, const std::error_condition & condition ) const BOOST_NOEXCEPT;
-    virtual bool equivalent( const std::error_code & code, int condition ) const BOOST_NOEXCEPT;
+    bool equivalent( int code, const std::error_condition & condition ) const BOOST_NOEXCEPT BOOST_OVERRIDE;
+    bool equivalent( const std::error_code & code, int condition ) const BOOST_NOEXCEPT BOOST_OVERRIDE;
 };
 
 #if !defined(__SUNPRO_CC) // trailing __global is not supported

--- a/include/boost/system/error_code.hpp
+++ b/include/boost/system/error_code.hpp
@@ -14,10 +14,10 @@
 #include <boost/system/detail/config.hpp>
 #include <boost/cstdint.hpp>
 #include <boost/config.hpp>
-#include <ostream>
-#include <string>
 #include <functional>
 #include <cstring>
+#include <ostream>
+#include <string>
 
 // TODO: undef these macros if not already defined
 #include <boost/cerrno.hpp>
@@ -287,13 +287,13 @@ public:
     {
     }
 
-    const char * name() const BOOST_NOEXCEPT
+    const char * name() const BOOST_NOEXCEPT BOOST_OVERRIDE
     {
         return "generic";
     }
 
-    std::string message( int ev ) const;
-    char const * message( int ev, char * buffer, std::size_t len ) const BOOST_NOEXCEPT;
+    std::string message( int ev ) const BOOST_OVERRIDE;
+    char const * message( int ev, char * buffer, std::size_t len ) const BOOST_NOEXCEPT BOOST_OVERRIDE;
 };
 
 class BOOST_SYMBOL_VISIBLE system_error_category: public error_category
@@ -305,15 +305,15 @@ public:
     {
     }
 
-    const char * name() const BOOST_NOEXCEPT
+    const char * name() const BOOST_NOEXCEPT BOOST_OVERRIDE
     {
         return "system";
     }
 
-    error_condition default_error_condition( int ev ) const BOOST_NOEXCEPT;
+    error_condition default_error_condition( int ev ) const BOOST_NOEXCEPT BOOST_OVERRIDE;
 
-    std::string message( int ev ) const;
-    char const * message( int ev, char * buffer, std::size_t len ) const BOOST_NOEXCEPT;
+    std::string message( int ev ) const BOOST_OVERRIDE;
+    char const * message( int ev, char * buffer, std::size_t len ) const BOOST_NOEXCEPT BOOST_OVERRIDE;
 };
 
 } // namespace detail

--- a/include/boost/system/system_error.hpp
+++ b/include/boost/system/system_error.hpp
@@ -8,10 +8,11 @@
 #ifndef BOOST_SYSTEM_SYSTEM_ERROR_HPP
 #define BOOST_SYSTEM_SYSTEM_ERROR_HPP
 
+#include <boost/config.hpp>
 #include <boost/system/error_code.hpp>
-#include <string>
-#include <stdexcept>
 #include <cassert>
+#include <stdexcept>
+#include <string>
 
 namespace boost
 {
@@ -44,10 +45,10 @@ namespace boost
         const char * what_arg )
           : std::runtime_error(what_arg), m_error_code(ev,ecat) {}
 
-      virtual ~system_error() BOOST_NOEXCEPT_OR_NOTHROW {}
+      ~system_error() BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE {}
 
       error_code code() const BOOST_NOEXCEPT { return m_error_code; }
-      const char * what() const BOOST_NOEXCEPT_OR_NOTHROW;
+      const char * what() const BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE;
 
     private:
       error_code           m_error_code;
@@ -80,5 +81,3 @@ namespace boost
 } // namespace boost
 
 #endif // BOOST_SYSTEM_SYSTEM_ERROR_HPP
-
-


### PR DESCRIPTION
Use BOOST_OVERRIDE to fix GCC -Wsuggest-override and Clang-tidy modernize-use-override warnings.
Alphabetical order of STL headers.