### PR TITLE
Define BOOST_SYSTEM_DEPRECATED for other compilers

### DIFF
--- a/include/boost/system/detail/config.hpp
+++ b/include/boost/system/detail/config.hpp
@@ -60,6 +60,8 @@
 # endif
 #elif defined(_MSC_VER)
 #  define BOOST_SYSTEM_DEPRECATED(msg) __declspec(deprecated(msg))
+#else
+# define BOOST_SYSTEM_DEPRECATED(msg)
 #endif
 
 #endif // BOOST_SYSTEM_DETAIL_CONFIG_HPP_INCLUDED


### PR DESCRIPTION
Currently compilation fails with Oracle Developer Studio 12.6, for example:

    $ ./b2 toolset=sun threading=multi variant=debug link=static cxxflags=-std=c++11 --with-system
    ...
    "./boost/system/detail/error_condition.hpp", line 96: Error: BOOST_SYSTEM_DEPRECATED is not defined.
    "./boost/system/detail/error_condition.hpp", line 96: Error: No direct declarator preceding ""this function is slated for removal"".
    "./boost/system/detail/error_condition.hpp", line 96: Error: No direct declarator preceding "(".