### PR TITLE
Fix error_category destructor

### DIFF
--- a/include/boost/system/detail/error_category.hpp
+++ b/include/boost/system/detail/error_category.hpp
@@ -84,7 +84,7 @@ protected:
 
 #if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS) && !defined(BOOST_NO_CXX11_NON_PUBLIC_DEFAULTED_FUNCTIONS)
 
-    ~error_category() = default;
+    virtual ~error_category() = default;
 
 #else
 

--- a/include/boost/system/detail/error_category.hpp
+++ b/include/boost/system/detail/error_category.hpp
@@ -80,22 +80,18 @@ private:
 
     boost::ulong_long_type id_;
 
+#if !defined(BOOST_NO_CXX11_NON_PUBLIC_DEFAULTED_FUNCTIONS)
+
 protected:
-
-#if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS) && !defined(BOOST_NO_CXX11_NON_PUBLIC_DEFAULTED_FUNCTIONS)
-
-    virtual ~error_category() = default;
-
+    virtual ~error_category() {}
 #else
 
-    // We'd like to make the destructor protected, to make code that deletes
-    // an error_category* not compile; unfortunately, doing the below makes
-    // the destructor user-provided and hence breaks use after main, as the
-    // categories may get destroyed before code that uses them
-
-    // ~error_category() {}
+public:
+    virtual ~error_category() {}
 
 #endif
+
+protected:
 
     BOOST_SYSTEM_CONSTEXPR error_category() BOOST_NOEXCEPT: id_( 0 )
     {

--- a/include/boost/system/detail/generic_category.hpp
+++ b/include/boost/system/detail/generic_category.hpp
@@ -33,6 +33,8 @@ namespace detail
 
 class BOOST_SYMBOL_VISIBLE generic_error_category: public error_category
 {
+    ~generic_error_category() override = default;
+
 public:
 
     BOOST_SYSTEM_CONSTEXPR generic_error_category() BOOST_NOEXCEPT:

--- a/include/boost/system/detail/generic_category.hpp
+++ b/include/boost/system/detail/generic_category.hpp
@@ -33,9 +33,9 @@ namespace detail
 
 class BOOST_SYMBOL_VISIBLE generic_error_category: public error_category
 {
-    ~generic_error_category() override = default;
-
 public:
+
+    ~generic_error_category() BOOST_OVERRIDE {};
 
     BOOST_SYSTEM_CONSTEXPR generic_error_category() BOOST_NOEXCEPT:
         error_category( detail::generic_category_id )

--- a/include/boost/system/detail/system_category.hpp
+++ b/include/boost/system/detail/system_category.hpp
@@ -32,9 +32,9 @@ namespace detail
 
 class BOOST_SYMBOL_VISIBLE system_error_category: public error_category
 {
-    ~system_error_category() override = default;
-
 public:
+
+    ~system_error_category() BOOST_OVERRIDE {};
 
     BOOST_SYSTEM_CONSTEXPR system_error_category() BOOST_NOEXCEPT:
         error_category( detail::system_category_id )

--- a/include/boost/system/detail/system_category.hpp
+++ b/include/boost/system/detail/system_category.hpp
@@ -32,6 +32,8 @@ namespace detail
 
 class BOOST_SYMBOL_VISIBLE system_error_category: public error_category
 {
+    ~system_error_category() override = default;
+
 public:
 
     BOOST_SYSTEM_CONSTEXPR system_error_category() BOOST_NOEXCEPT:


### PR DESCRIPTION
destruct of the error_category that is an abstract class, should be virtual for the correct inheritance of this class.
Unfortunately it is not possible to use this class as base class in projects with an enabled compile warning -Werror=non-virtual-dtor, where all compiler warnings are treated as errors.
