### PR TITLE
Define BOOST_SYSTEM_DEPRECATED for Oracle Developer Studio

### DIFF
--- a/include/boost/system/detail/config.hpp
+++ b/include/boost/system/detail/config.hpp
@@ -60,6 +60,8 @@
 # endif
 #elif defined(_MSC_VER)
 #  define BOOST_SYSTEM_DEPRECATED(msg) __declspec(deprecated(msg))
+#elif defined(__sun)
+#  define BOOST_SYSTEM_DEPRECATED(msg) __attribute__((deprecated(msg)))
 #else
 # define BOOST_SYSTEM_DEPRECATED(msg)
 #endif


### PR DESCRIPTION
Added Oracle Developer Studio specific define. This will generate warning if function is used on source file