### PR TITLE
Add support for Windows error code ERROR_NOT_SUPPORTED

### DIFF
--- a/include/boost/system/detail/system_category_condition_win32.hpp
+++ b/include/boost/system/detail/system_category_condition_win32.hpp
@@ -97,6 +97,7 @@ inline int system_category_condition_win32( int ev ) BOOST_NOEXCEPT
     case ERROR_RETRY_: return resource_unavailable_try_again;
     case ERROR_SEEK_: return io_error;
     case ERROR_SHARING_VIOLATION_: return permission_denied;
+    case ERROR_NOT_SUPPORTED_: return not_supported; // WinError.h: "The request is not supported."
     case ERROR_TOO_MANY_OPEN_FILES_: return too_many_files_open;
     case ERROR_WRITE_FAULT_: return io_error;
     case ERROR_WRITE_PROTECT_: return permission_denied;

--- a/include/boost/system/windows_error.hpp
+++ b/include/boost/system/windows_error.hpp
@@ -72,7 +72,8 @@ namespace boost
         wrong_disk = boost::winapi::ERROR_WRONG_DISK_,
         sharing_buffer_exceeded = boost::winapi::ERROR_SHARING_BUFFER_EXCEEDED_,
         handle_eof = boost::winapi::ERROR_HANDLE_EOF_,
-        handle_disk_full= boost::winapi::ERROR_HANDLE_DISK_FULL_,
+        handle_disk_full = boost::winapi::ERROR_HANDLE_DISK_FULL_,
+        not_supported = boost::winapi::ERROR_NOT_SUPPORTED_,
         rem_not_list = boost::winapi::ERROR_REM_NOT_LIST_,
         dup_name = boost::winapi::ERROR_DUP_NAME_,
         bad_net_path = boost::winapi::ERROR_BAD_NETPATH_,
@@ -84,7 +85,7 @@ namespace boost
         broken_pipe = boost::winapi::ERROR_BROKEN_PIPE_,
         open_failed = boost::winapi::ERROR_OPEN_FAILED_,
         buffer_overflow = boost::winapi::ERROR_BUFFER_OVERFLOW_,
-        disk_full= boost::winapi::ERROR_DISK_FULL_,
+        disk_full = boost::winapi::ERROR_DISK_FULL_,
         // ...
         lock_failed = boost::winapi::ERROR_LOCK_FAILED_,
         busy = boost::winapi::ERROR_BUSY_,


### PR DESCRIPTION
The error code description reads as "The request is not supported," which is close to POSIX `EOPNOTSUPP` "Operation not supported."