### PR TITLE
Add __attribute__((__format__)) to snprintf

### DIFF
--- a/include/boost/system/detail/snprintf.hpp
+++ b/include/boost/system/detail/snprintf.hpp
@@ -49,6 +49,9 @@ inline void snprintf( char * buffer, std::size_t len, char const * format, ... )
 
 #else
 
+#if __GNUC__ >= 3
+__attribute__((__format__ (__printf__, 3, 4)))
+#endif
 inline void snprintf( char * buffer, std::size_t len, char const * format, ... )
 {
     va_list args;


### PR DESCRIPTION
This attribute will check format string bugs and is required for clean compile if -Wformat-nonliteral is enabled.