### PR TITLE
Fix error_code's operator<< for arbitrary basic_ostream specializations

### DIFF
--- a/include/boost/system/detail/error_code.hpp
+++ b/include/boost/system/detail/error_code.hpp
@@ -604,7 +604,7 @@ public:
         inline friend std::basic_ostream<Ch, Tr>&
         operator<< (std::basic_ostream<Ch, Tr>& os, error_code const & ec)
     {
-        return os << ec.to_string();
+        return os << ec.to_string().c_str();
     }
 
     std::string what() const


### PR DESCRIPTION
This fixes a regression from commit
https://github.com/boostorg/system/commit/a9b64a888a24400cc2af9910a6ff88c3c4fd3210.
Calling `operator<<` with `std::string` only works for `std::ostream`.
Use `c_str()` to restore the previous behavior of using `const char*`,
which works for any `basic_ostream` specialization.