### PR TITLE
Constexpr default ctor

### DIFF
--- a/include/boost/system/detail/error_code.hpp
+++ b/include/boost/system/detail/error_code.hpp
@@ -114,7 +114,10 @@ public:
 
     // constructors:
 
-    BOOST_SYSTEM_CONSTEXPR error_code() BOOST_NOEXCEPT:
+#if ! BOOST_WORKAROUND(BOOST_GCC, < 40800)
+    BOOST_CONSTEXPR
+#endif
+    error_code() BOOST_NOEXCEPT:
         d1_(), lc_flags_( 0 )
     {
     }


### PR DESCRIPTION
This makes `error_code` default constructor `constexpr` in C++11 instead of just C++14