### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -5,13 +5,15 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/config//boost_config
+    /boost/throw_exception//boost_throw_exception
+    /boost/variant2//boost_variant2
+    /boost/winapi//boost_winapi ;
+
 project /boost/system
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/config//boost_config
-        <library>/boost/throw_exception//boost_throw_exception
-        <library>/boost/variant2//boost_variant2
-        <library>/boost/winapi//boost_winapi
         <include>include
     ;
 
@@ -23,3 +25,4 @@ explicit
 call-if : boost-library system
     : install boost_system
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,25 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/system
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/config//boost_config
+        <source>/boost/throw_exception//boost_throw_exception
+        <source>/boost/variant2//boost_variant2
+        <source>/boost/winapi//boost_winapi
+        <include>include
+    ;
+
+explicit
+    [ alias boost_system : build//boost_system ]
+    [ alias all : boost_system test ]
+    ;
+
+call-if : boost-library system
+    : install boost_system
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/system

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/system
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -7,11 +7,11 @@ import project ;
 
 project /boost/system
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/config//boost_config
-        <source>/boost/throw_exception//boost_throw_exception
-        <source>/boost/variant2//boost_variant2
-        <source>/boost/winapi//boost_winapi
+        <library>/boost/assert//boost_assert
+        <library>/boost/config//boost_config
+        <library>/boost/throw_exception//boost_throw_exception
+        <library>/boost/variant2//boost_variant2
+        <library>/boost/winapi//boost_winapi
         <include>include
     ;
 

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -7,7 +7,7 @@
 
 # See library home page at https://www.boost.org/libs/system
 
-project boost/system
+project
     : source-location ../src
     : usage-requirements  # pass these requirement to dependents (i.e. users)
       <link>shared:<define>BOOST_SYSTEM_DYN_LINK=1
@@ -21,5 +21,3 @@ lib boost_system
    : <link>shared:<define>BOOST_SYSTEM_DYN_LINK=1
      <link>static:<define>BOOST_SYSTEM_STATIC_LINK=1
    ;
-
-boost-install boost_system ;

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -9,6 +9,7 @@
 
 project
     : source-location ../src
+    : common-requirements <library>$(boost_dependencies)
     : usage-requirements  # pass these requirement to dependents (i.e. users)
       <link>shared:<define>BOOST_SYSTEM_DYN_LINK=1
       <link>static:<define>BOOST_SYSTEM_STATIC_LINK=1

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -12,6 +12,7 @@ project
     : usage-requirements  # pass these requirement to dependents (i.e. users)
       <link>shared:<define>BOOST_SYSTEM_DYN_LINK=1
       <link>static:<define>BOOST_SYSTEM_STATIC_LINK=1
+      <define>BOOST_SYSTEM_NO_LIB=1
     ;
 
 SOURCES = error_code ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -17,6 +17,8 @@ project
 
   : requirements
 
+    <source>/boost/core//boost_core
+
     <toolset>msvc:<warnings-as-errors>on
     <toolset>gcc:<warnings-as-errors>on
     <toolset>clang:<warnings-as-errors>on

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -17,7 +17,7 @@ project
 
   : requirements
 
-    <source>/boost/core//boost_core
+    <library>/boost/core//boost_core
 
     <toolset>msvc:<warnings-as-errors>on
     <toolset>gcc:<warnings-as-errors>on

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -17,6 +17,8 @@ project
 
   : requirements
 
+    <library>/boost/system//boost_system
+
     <library>/boost/core//boost_core
 
     <toolset>msvc:<warnings-as-errors>on


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.