### PR TITLE
Update system_category_message_win32.hpp

### DIFF
--- a/include/boost/system/detail/system_category_message_win32.hpp
+++ b/include/boost/system/detail/system_category_message_win32.hpp
@@ -73,7 +73,7 @@ inline char const * system_category_message_win32( int ev, char * buffer, std::s
         DWORD_ retval = boost::winapi::FormatMessageA(
             FORMAT_MESSAGE_FROM_SYSTEM_ | FORMAT_MESSAGE_IGNORE_INSERTS_,
             NULL,
-            ev,
+            static_cast<DWORD_>(ev),
             MAKELANGID_( LANG_NEUTRAL_, SUBLANG_DEFAULT_ ), // Default language
             buffer,
             static_cast<DWORD_>( len ),
@@ -94,7 +94,7 @@ inline char const * system_category_message_win32( int ev, char * buffer, std::s
         DWORD_ retval = boost::winapi::FormatMessageW(
             FORMAT_MESSAGE_ALLOCATE_BUFFER_ | FORMAT_MESSAGE_FROM_SYSTEM_ | FORMAT_MESSAGE_IGNORE_INSERTS_,
             NULL,
-            ev,
+            static_cast<DWORD_>(ev),
             MAKELANGID_( LANG_NEUTRAL_, SUBLANG_DEFAULT_ ), // Default language
             (LPWSTR_) &lpMsgBuf,
             0,
@@ -152,7 +152,7 @@ inline std::string system_category_message_win32( int ev )
     DWORD_ retval = boost::winapi::FormatMessageW(
         FORMAT_MESSAGE_ALLOCATE_BUFFER_ | FORMAT_MESSAGE_FROM_SYSTEM_ | FORMAT_MESSAGE_IGNORE_INSERTS_,
         NULL,
-        ev,
+        static_cast<DWORD_>(ev),
         MAKELANGID_( LANG_NEUTRAL_, SUBLANG_DEFAULT_ ), // Default language
         (LPWSTR_) &lpMsgBuf,
         0,
@@ -176,7 +176,7 @@ inline std::string system_category_message_win32( int ev )
         return unknown_message_win32( ev );
     }
 
-    std::string buffer( r, char() );
+    std::string buffer( static_cast<std::size_t>(r), char() );
 
     r = boost::winapi::WideCharToMultiByte( code_page, 0, lpMsgBuf, -1, &buffer[0], r, NULL, NULL );
 
@@ -187,12 +187,12 @@ inline std::string system_category_message_win32( int ev )
 
     --r; // exclude null terminator
 
-    while( r > 0 && ( buffer[ r-1 ] == '\n' || buffer[ r-1 ] == '\r' ) )
+    while( r > 0 && ( buffer[ static_cast<std::size_t>(r)-1 ] == '\n' || buffer[ static_cast<std::size_t>(r)-1 ] == '\r' ) )
     {
         --r;
     }
 
-    if( r > 0 && buffer[ r-1 ] == '.' )
+    if( r > 0 && buffer[ static_cast<std::size_t>(r)-1 ] == '.' )
     {
         --r;
     }


### PR DESCRIPTION
Fixes for Wsign-conversion with MinGW64 ("conversion to 'DWORD' {aka 'long unsigned int'} from 'int' may change the sign of the result")