### PR TITLE
Improve interoperability with std::system_error

### DIFF
--- a/include/boost/system/system_error.hpp
+++ b/include/boost/system/system_error.hpp
@@ -10,6 +10,7 @@
 #include <boost/system/detail/error_code.hpp>
 #include <string>
 #include <stdexcept>
+#include <system_error>
 #include <cassert>
 
 namespace boost
@@ -17,35 +18,14 @@ namespace boost
 namespace system
 {
 
-class BOOST_SYMBOL_VISIBLE system_error: public std::runtime_error
+class BOOST_SYMBOL_VISIBLE system_error: public std::system_error
 {
-private:
-
-    error_code code_;
-
 public:
-
-    explicit system_error( error_code const & ec ):
-        std::runtime_error( ec.what() ), code_( ec ) {}
-
-    system_error( error_code const & ec, std::string const & prefix ):
-        std::runtime_error( prefix + ": " + ec.what() ), code_( ec ) {}
-
-    system_error( error_code const & ec, char const * prefix ):
-        std::runtime_error( std::string( prefix ) + ": " + ec.what() ), code_( ec ) {}
-
-    system_error( int ev, error_category const & ecat ):
-        std::runtime_error( error_code( ev, ecat ).what() ), code_( ev, ecat ) {}
-
-    system_error( int ev, error_category const & ecat, std::string const & prefix ):
-        std::runtime_error( prefix + ": " + error_code( ev, ecat ).what() ), code_( ev, ecat ) {}
-
-    system_error( int ev, error_category const & ecat, char const * prefix ):
-        std::runtime_error( std::string( prefix ) + ": " + error_code( ev, ecat ).what() ), code_( ev, ecat ) {}
+    using std::system_error::system_error;
 
     error_code code() const noexcept
     {
-        return code_;
+        return std::system_error::code();
     }
 };
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -142,6 +142,7 @@ run std_interop_test10.cpp ;
 run ec_location_test2.cpp ;
 run ec_what_test.cpp ;
 run system_error_test3.cpp ;
+run system_error_test4.cpp ;
 
 run std_interop_test11.cpp ;
 

--- a/test/system_error_test4.cpp
+++ b/test/system_error_test4.cpp
@@ -1,0 +1,21 @@
+// Copyright 2021, 2022 Peter Dimov
+// Distributed under the Boost Software License, Version 1.0
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/system/system_error.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <cerrno>
+
+namespace sys = boost::system;
+
+int main()
+{
+    try {
+        sys::error_code ec( 5, sys::generic_category() );
+        throw sys::system_error( ec );
+    } catch (const std::system_error& err) {
+        // fine
+    }
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
While migrating Boost.DLL to std::error_code https://github.com/boostorg/dll/pull/76 I've noticed that boost::system_error is not related to std::system_error. Because of that, users have to duplicate the catch blocks if there's a need to wor with error code:
```cpp
try {
  some_throwing_function();
} catch (const std::system_error& err) {
  process_error_code(err.code());
} catch (const boost::system::system_error& err) {
  process_error_code(err.code());
}
```

This PR shows how the seconds catch block could be eliminated. is there interest in such functionality? The output of e.what() changes, is that OK?