### PR TITLE
Use BOOST_POSIX_API on cygwin.

### DIFF
--- a/include/boost/system/api_config.hpp
+++ b/include/boost/system/api_config.hpp
@@ -33,7 +33,7 @@
 //    Standalone MinGW and all other known Windows compilers do predefine _WIN32
 //    Compilers that predefine _WIN32 or __MINGW32__ do so for Windows 64-bit builds too.
 
-# if defined(_WIN32) || defined(__CYGWIN__) // Windows default, including MinGW and Cygwin
+# if defined(_WIN32) // Windows default, including MinGW
 #   define BOOST_WINDOWS_API
 # else
 #   define BOOST_POSIX_API 


### PR DESCRIPTION
This is part of a set of changes to fix boost on cygwin.  You can see the other submodules that will require changes here:

https://github.com/boostorg/boost/compare/master...corngood:boost:cygwin

These are based on the out-of-date downstream patches in cygwin:

https://cygwin.com/cgit/cygwin-packages/boost/tree/